### PR TITLE
line separation and readme

### DIFF
--- a/README.ru.txt
+++ b/README.ru.txt
@@ -14,7 +14,7 @@ usage: zkTreeUtil
                                    a normal, empty directory)
  -of,--output-file <filename>      output file to which znode information
                                    should be written
- -xf,--output-xmlfile <filename>   output xml-file to which znode
+ -ox,--output-xmlfile <filename>   output xml-file to which znode
                                    information should be written
  -p,--path <znodepath>             path to the zookeeper subtree rootnode.
  -z,--zookeeper <zkhosts>          zookeeper remote servers (ie

--- a/README.txt
+++ b/README.txt
@@ -16,7 +16,7 @@ usage: zkTreeUtil
                                    a normal, empty directory)
  -of,--output-file <filename>      output file to which znode information
                                    should be written
- -xf,--output-xmlfile <filename>   output xml-file to which znode
+ -ox,--output-xmlfile <filename>   output xml-file to which znode
                                    information should be written
  -p,--path <znodepath>             path to the zookeeper subtree rootnode.
  -z,--zookeeper <zkhosts>          zookeeper remote servers (ie

--- a/src/main/java/com/dobrunov/zktreeutil/zkExportToFile.java
+++ b/src/main/java/com/dobrunov/zktreeutil/zkExportToFile.java
@@ -64,7 +64,7 @@ public class zkExportToFile implements Job {
                 if (znode.data.stat.getEphemeralOwner() != 0) {
                     writer.write("type='ephemeral'");
                 }
-                writer.write("\r\n");
+                writer.write(System.lineSeparator());
             }
             writer.flush();
         } catch (Exception e) {


### PR DESCRIPTION
fixed line separation for linux systems. 
fixed readme - parameter for xml file is ox not xf.
