### PR TITLE
Tab symbol is inserted only when node has no data or node is ephemeral

### DIFF
--- a/src/main/java/com/dobrunov/zktreeutil/zkExportToFile.java
+++ b/src/main/java/com/dobrunov/zktreeutil/zkExportToFile.java
@@ -53,15 +53,16 @@ public class zkExportToFile implements Job {
             writer = new FileWriter(output_file);
             for (TreeNode<zNode> znode : zktree) {
                 writer.write("path=" + start_znode + znode.data.path);
-                writer.write("\t");
                 if (znode.data.data != null && znode.data.data.length > 0) {
                     String str = new String(znode.data.data);
                     if (!str.equals("null")) {
+                        writer.write("\t");
                         writer.write("val=" + str);
                     }
                 }
-                writer.write("\t");
+
                 if (znode.data.stat.getEphemeralOwner() != 0) {
+                    writer.write("\t");
                     writer.write("type='ephemeral'");
                 }
                 writer.write(System.lineSeparator());


### PR DESCRIPTION
The bug resulted in leaving trailing tabs when node has no value or node has value but is not ephemeral.

Suppose we have a node /path/to/node/password with value: password. Current implementation leaves trailing tab after val=password, resulting in invalid password
`path=/path/to/node/password	val=password	`