### PR TITLE
added log4j.properties to unix launch script

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -54,3 +54,9 @@ Build instructions
 1. cd into this directory
 2. mvn clean package
 3. 'zkTreeUtil' created in target\distrib directory
+
+To run from an IDE (for example intellij)
+-----------------------------------------
+The main class is com.dobrunov.zktreeutil.zkTreeUtilMain
+To enable logging, add the vm argument -Dlog4j.configuration=bin/log4j.properties
+This is not required if you're running directly from 'zkTreeUtil' created in target\distrib directory

--- a/src/main/resources/bin/zktreeutil.sh
+++ b/src/main/resources/bin/zktreeutil.sh
@@ -3,5 +3,5 @@
 #echo Uadmin
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cp="$DIR/../lib/*"
+cp="$DIR/:$DIR/../lib/*"
 java -cp "$cp" com.dobrunov.zktreeutil.zkTreeUtilMain $@


### PR DESCRIPTION
Thanks for this project. It really helped us debug a production outage!
However the logging was broken for linux/unix because the log4j.properties was not added to unix path.

For newbies it takes a lot of time to figure out why logging is not working.

Please accept the Pull request to fix it